### PR TITLE
Optimise storage variables ordering

### DIFF
--- a/contracts/ColonyTokenSale.sol
+++ b/contracts/ColonyTokenSale.sol
@@ -14,13 +14,14 @@ contract ColonyTokenSale is DSMath {
   uint public minToRaise;
   uint public totalRaised = 1 finney;
   uint public softCap;
+  uint public saleFinalizedTime;
+
   bool endBlockUpdatedAtSoftCap = false;
   bool public saleStopped = false;
   bool public saleFinalized = false;
-  uint public saleFinalizedTime;
-  address public colonyMultisig;
   Token public token;
 
+  address public colonyMultisig;
   uint constant public TOKEN_PRICE_MULTIPLIER = 1000;
   uint constant public MIN_CONTRIBUTION = 10 finney;
   uint constant internal SECONDS_PER_MONTH = 2628000;


### PR DESCRIPTION
Since this commit 
https://github.com/JoinColony/colonySale/commit/b639e720b399573dcbdbeaa73fe3e3aa44843d5f#diff-9d6eae55b60dddabb71a9fad55ffc1cc
the cost of `buy` transaction which sets the `endBlockUpdatedAtSoftCap` boolean to `true` increased by ~15,000 gas. This was due to the effect the committed change had on the ordering of storage variables in the contract from 
`uint`, `address`, `bool`, `bool`, `bool`, `uint` 
to
`uint`, `bool`, `bool`, `bool`, `uint`, `address`

Considering the size in storage of these types, namely:
uint => 256 bits
bool => 8 bits
address => 160 bits
(ref: https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI#types)

The ordering of 32 bytes storage slots in both case was respectively:
slot_X: `uint`
slot_Y: `address`, `bool`, `bool`, `bool`
slot_Z: `uint`

and after changed to
slot_X: `uint`
slot_Y: `bool`, `bool`, `bool`
slot_F: `address` 
slot_Z: `uint`

The address variable (i.e. Token address) was set in the contract constructor, therefore `slot_Y` in the first example was already non-zero when the boolean was set to `true`, incurring only 5,000 gas cost. Whereas in the second example `slot_Y` was set from zero to non-zero (as the address property was not already part of it) incurring 20,000 gas cost, leading to the 15,000 gas cost difference.

Ref: Yellow paper:
>20000 Paid for an SSTORE operation when the storage value is set to non-zero from zero.
>5000 Paid for an SSTORE operation when the storage value’s zeroness remains unchanged or is set to zero.

This PR fixes this storage variables optimisation.